### PR TITLE
Critical Security Fix & State Bag Implementation for Clock-in Status

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,17 +1,9 @@
-local afkTimeout = Config.AFKClockoutTime * 60
 local lastPosition = nil
-
 TriggerEvent('chat:addSuggestion', '/clockin', 'Clock in as a staff member', {})
 TriggerEvent('chat:addSuggestion', '/clockout', 'Clock out as a staff member', {})
 
-RegisterNetEvent("receiveAFKTimeout")
-AddEventHandler("receiveAFKTimeout", function(timeout)
-    afkTimeout = timeout * 60 
-    print("AFK Timeout set to: " .. (afkTimeout / 60) .. " minutes") 
-end)
-
 RegisterNetEvent("showAFKDialog")
-AddEventHandler("showAFKDialog", function()
+AddEventHandler("showAFKDialog", function(afkTimeout)
     local alert = lib.alertDialog({
         header = 'Staff API',
         content = 'You have been clocked in and inactive for more than ' .. (afkTimeout / 60) .. ' minutes. You have been clocked out.',

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,11 @@
 Config = {
     AcePerm = "staff.clockin",
-    Webhook = "",
+    BypassAcePerm = "clockin.bypass",
+    Webhook = "CHANGE_ME",
     NotifyDuration = 8000,
-	AFKClockoutTime = 1, -- In Minutes
-    Notify = 4,  -- 0 = (chatmessage) 1 = (okokNotify) 2 = (codem/venice) 3 = (mythic) 4 = (ox_lib)
+    AFKClockoutTime = 1, -- In Minutes
+    Notify = 4  -- 0 = (chatmessage) 1 = (okokNotify) 2 = (codem/venice) 3 = (mythic) 4 = (ox_lib)
 }
+
+-- exports["chimera-staff-clockin"]:StaffClockin(source, "Some reason")
+-- exports["chimera-staff-clockin"]:StaffClockout(source, "Some reason")

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,10 +8,7 @@ lua54 'yes'
 
 dependency 'ox_lib'
 
-shared_script 'config.lua'
-
 shared_scripts {
-  "config.lua",
   "@ox_lib/init.lua",
   "functions.lua"
 }
@@ -21,5 +18,6 @@ client_scripts {
 }
 
 server_scripts {
+  'config.lua',
 	'server.lua'
 }

--- a/server.lua
+++ b/server.lua
@@ -129,10 +129,6 @@ AddEventHandler("playerDropped", function(reason)
     end
 end)
 
-function formatTime(seconds)
-    return "<t:" .. seconds .. ">"
-end
-
 exports("StaffClockin", function(source, reason)
     clockInPlayer(source, reason or "Manual Clock-in")
 end)


### PR DESCRIPTION
- Moved config.lua to a server script to prevent the client from accessing discord webhook
- Added state bags to enable checking clock in status from both the client and server of any script
  - Client Example:
   `if LocalPlayer.state['chimera-staff:clockedin'] then`
  - Server Example:
   `if Player(source).state['chimera-staff:clockedin'] then`
- Removed unused and duplicate functions
- Removed a call to a client event that didn't exist?
